### PR TITLE
Add AUTHORS file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Daniel Patrick <daniel.patrick@netways.de> <dani.p1991@gmail.com>
+Thomas Widhalm <thomas.widhalm@netways.de> <widhalmt@widhalm.or.at>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,2 @@
+Daniel Patrick <daniel.patrick@netways.de>
+Thomas Widhalm <thomas.widhalm@netways.de>


### PR DESCRIPTION
Now that we have multiple contributors, we should add an `AUTHORS` file.

@DanOPT please let me know if `.mailmap` is built like you want to be represented. I just assumed you wanted it the same way as in other Repositories, but if I'm wrong, please just let me know.